### PR TITLE
Add hardware timestamping to socketcan.c

### DIFF
--- a/examples/CAN/host-example-01-opencyphal-basic-node/socketcan.c
+++ b/examples/CAN/host-example-01-opencyphal-basic-node/socketcan.c
@@ -15,6 +15,8 @@
 #    include <net/if.h>
 #    include <sys/ioctl.h>
 #    include <sys/socket.h>
+#    include <linux/net_tstamp.h>
+#    include <linux/errqueue.h>
 #else
 #    error "Unsupported OS -- feel free to add support for your OS here. " \
         "Zephyr and NuttX are known to support the SocketCAN API."
@@ -31,6 +33,8 @@
 
 #define KILO 1000L
 #define MEGA (KILO * KILO)
+#define NANOSECONDS_PER_SECOND 1000000000LL
+#define NANOSECONDS_PER_MICROSECOND 1000LL
 
 static int16_t getNegatedErrno(void)
 {
@@ -49,6 +53,19 @@ static int16_t getNegatedErrno(void)
     return INT16_MIN;
 }
 
+/**
+ * A wrapper function for the ppoll() system call.
+ *
+ * This function waits for a specific event (or timeout) on a single file descriptor (fd).
+ *
+ * @param fd      The file descriptor (socketcan handle) to poll.
+ * @param mask    A bitmask specifying the events we are interested in (e.g., POLLIN, POLLOUT).
+ * @param timeout_usec The maximum time to wait for an event, in microseconds.
+ *
+ * @return 1 on success (the requested event occurred).
+ * @return 0 on timeout (no event occurred within the time limit).
+ * @return < 0 on error (a negative errno value).
+ */
 static int16_t doPoll(const SocketCANFD fd, const int16_t mask, const CanardMicrosecond timeout_usec)
 {
     struct pollfd fds;
@@ -61,23 +78,113 @@ static int16_t doPoll(const SocketCANFD fd, const int16_t mask, const CanardMicr
     ts.tv_nsec = (long) (timeout_usec % (CanardMicrosecond) MEGA) * KILO;
 
     const int poll_result = ppoll(&fds, 1, &ts, NULL);
-    if (poll_result < 0)
-    {
+    // A negative result from poll indicates a system error (e.g., bad memory address).
+    if (poll_result < 0) {
         return getNegatedErrno();
     }
-    if (poll_result == 0)
-    {
+
+    // timeout expired without any of the requested events happening.
+    if (poll_result == 0) {
         return 0;
     }
-    if (((uint32_t) fds.revents & (uint32_t) mask) == 0)
-    {
+
+    // If we get here, means an event did happen.
+    // The kernel has updated 'fds.revents' to tell us what it was.
+    const uint32_t revents = (uint32_t)fds.revents;
+
+    // Did we request to check for data available to read?
+    if (((uint32_t)mask & (uint32_t)POLLIN) != 0) {
+
+        // Check if data available to read
+        if ((revents & (uint32_t)POLLIN) != 0) {
+            // printf("Data available to read\n");
+            return 1;
+        }
+
+        // Check if error queue contains data
+        if ((revents & (uint32_t)POLLERR) != 0) {
+            // printf("Error queue contains data\n");
+            return 1;  // errqueue wakes here
+        }
+    }
+
+    // Did we request to check for ability to write data?
+    if (((uint32_t)mask & (uint32_t)POLLOUT) != 0) {
+
+        // Check if writing to the Socket will not block (buffer space available)
+        if ((revents & (uint32_t)POLLOUT) != 0) {
+        return 1;
+      }
+    }
+
+    // This block catches any error events.
+    // POLLHUP  = "Poll Hang Up". The other end disconnected.
+    // POLLNVAL = "Poll Invalid". The file descriptor is invalid (e.g., closed).
+    if (revents & ((uint32_t)POLLERR | (uint32_t)POLLHUP | (uint32_t)POLLNVAL)) {
+        int soerr = 0;
+        socklen_t slen = sizeof(soerr);
+
+        if (getsockopt(fd, SOL_SOCKET, SO_ERROR, &soerr, &slen) == 0 && soerr != 0) {
+            errno = soerr;
+            return getNegatedErrno();
+        }
         return -EIO;
     }
 
-    return 1;
+    return -EIO;
 }
 
-SocketCANFD socketcanOpen(const char* const iface_name, const bool can_fd)
+/**
+ * Convert a timespec structure to nanoseconds.
+ *
+ * @param ts The timespec structure to convert.
+ *
+ * @return The equivalent time in nanoseconds.
+ */
+static inline int64_t timespecToNanoseconds(const struct timespec* ts)
+{
+    return ((int64_t)ts->tv_sec * NANOSECONDS_PER_SECOND) + (int64_t)ts->tv_nsec;
+}
+
+/**
+ * Parse the timestamping control message from a received socket message.
+ * @param msg The message header containing control messages.
+ * @param tss_out An array to store the extracted timestamps.
+ *
+ * @return true if the timestamping control message was found and parsed, false otherwise.
+ */
+static inline bool parseTimestampingCmsg(const struct msghdr* msg, struct timespec tss_out[3])
+{
+    for (struct cmsghdr* c = CMSG_FIRSTHDR((struct msghdr*)msg); c; c = CMSG_NXTHDR((struct msghdr*)msg, c)) {
+        if (c->cmsg_level == SOL_SOCKET && c->cmsg_type == SCM_TIMESTAMPING) {
+            (void)memcpy(tss_out, CMSG_DATA(c), sizeof(struct timespec[3]));
+            return true;
+        }
+    }
+    return false;
+}
+
+static inline bool parseTxIDFromErrqueue(const struct msghdr* msg, uint32_t* out_id)
+{
+    for (struct cmsghdr* c = CMSG_FIRSTHDR((struct msghdr*)msg); c; c = CMSG_NXTHDR((struct msghdr*)msg, c)) {
+        if (c->cmsg_len >= CMSG_LEN(sizeof(struct sock_extended_err))) {
+            struct sock_extended_err se;
+            memcpy(&se, CMSG_DATA(c), sizeof(se));
+
+            if (se.ee_origin == SO_EE_ORIGIN_TIMESTAMPING) {
+                if (out_id) {
+                    *out_id = se.ee_data;
+                }
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+SocketCANFD socketcanOpen(const char* const iface_name, const bool can_fd,
+                          const bool en_rx_timestamping, const bool en_tx_timestamping,
+                          const bool enable_frame_reception)
 {
     const size_t iface_name_size = strlen(iface_name) + 1;
     if (iface_name_size > IFNAMSIZ)
@@ -111,14 +218,29 @@ SocketCANFD socketcanOpen(const char* const iface_name, const bool can_fd)
         ok           = 0 == setsockopt(fd, SOL_CAN_RAW, CAN_RAW_FD_FRAMES, &en, sizeof(en));
     }
 
-    // Enable timestamping.
-    if (ok)
-    {
-        const int en = 1;
-        ok           = 0 == setsockopt(fd, SOL_SOCKET, SO_TIMESTAMP, &en, sizeof(en));
+    // Enable or disable frame reception for this socket.
+    if (ok && !enable_frame_reception) {
+        setsockopt(fd, SOL_CAN_RAW, CAN_RAW_FILTER, NULL, 0);
     }
 
-    // // Enable outgoing-frame loop-back.
+    // Enable timestamping.
+    if (ok) {
+        unsigned int ts_flags =
+            (en_rx_timestamping ? (unsigned int)SOF_TIMESTAMPING_RX_HARDWARE |
+                                  (unsigned int)SOF_TIMESTAMPING_RX_SOFTWARE
+                                  : 0) |
+            (en_tx_timestamping ? (unsigned int)SOF_TIMESTAMPING_TX_HARDWARE |
+                                  (unsigned int)SOF_TIMESTAMPING_TX_SOFTWARE
+                                  : 0) |
+                                  (unsigned int)SOF_TIMESTAMPING_RAW_HARDWARE |
+                                  (unsigned int)SOF_TIMESTAMPING_SOFTWARE |
+                                  (unsigned int)SOF_TIMESTAMPING_OPT_TX_SWHW |
+                                  (unsigned int)SOF_TIMESTAMPING_OPT_TSONLY |
+                                  (unsigned int)SOF_TIMESTAMPING_OPT_ID;
+        ok = 0 == setsockopt(fd, SOL_SOCKET, SO_TIMESTAMPING, &ts_flags, sizeof(ts_flags));
+    }
+
+    // Enable outgoing-frame loop-back.
     // if (ok)
     // {
     //     const int en = 1;
@@ -197,12 +319,11 @@ int16_t socketcanPop(const SocketCANFD        fd,
         // We require space for both the receive message header (implied in CMSG_SPACE) and the time stamp.
         // The ancillary data buffer is wrapped in a union to ensure it is suitably aligned.
         // See the cmsg(3) man page (release 5.08 dated 2020-06-09, or later) for details.
-        union
-        {
-            uint8_t        buf[CMSG_SPACE(sizeof(struct timeval))];
-            struct cmsghdr align;
+        union {
+          uint8_t buf[CMSG_SPACE(sizeof(struct timespec[3]))];
+          struct cmsghdr align;
         } control;
-        (void) memset(control.buf, 0, sizeof(control.buf));
+        (void)memset(control.buf, 0, sizeof(control.buf));
 
         // Initialize the message header used by recvmsg.
         struct msghdr msg  = {0};                  // Message header struct.
@@ -213,24 +334,28 @@ int16_t socketcanPop(const SocketCANFD        fd,
 
         // Non-blocking receive messages from the socket and validate.
         const ssize_t read_size = recvmsg(fd, &msg, MSG_DONTWAIT);
-        if (read_size < 0)
-        {
-            return getNegatedErrno();  // Error occurred -- return the negated error code.
+        if (read_size < 0) {
+            // This can happen if poll() wakes on POLLERR but the error is cleared
+            // before we call recvmsg(). Treat it as a non-event.
+            if (errno == EAGAIN || errno == EWOULDBLOCK) {
+                return 0;
+            }
+            return getNegatedErrno();  // Real error -> propagate
         }
+
         if ((read_size != CAN_MTU) && (read_size != CANFD_MTU))
         {
             return -EIO;
         }
+
         if (sockcan_frame.len > payload_buffer_size)
         {
             return -EFBIG;
         }
 
-        // printf("RX = CAN ID:0x%x, Length:%d, Flags:%d\n", sockcan_frame.can_id, sockcan_frame.len, sockcan_frame.flags);
-
         const bool valid = ((sockcan_frame.can_id & CAN_EFF_FLAG) != 0) &&  // Extended frame
-                           ((sockcan_frame.can_id & CAN_ERR_FLAG) == 0) &&  // Not RTR frame
-                           ((sockcan_frame.can_id & CAN_RTR_FLAG) == 0);    // Not error frame
+                           ((sockcan_frame.can_id & CAN_ERR_FLAG) == 0) &&  // Not Error frame
+                           ((sockcan_frame.can_id & CAN_RTR_FLAG) == 0);    // Not RTR frame
         if (!valid)
         {
             return 0;  // Not an extended data frame -- drop silently and return early.
@@ -242,6 +367,7 @@ int16_t socketcanPop(const SocketCANFD        fd,
         {
             return 0;  // The loopback pointer is NULL and this is a loopback frame -- drop silently and return early.
         }
+
         if (loopback != NULL)
         {
             *loopback = loopback_frame;
@@ -249,25 +375,25 @@ int16_t socketcanPop(const SocketCANFD        fd,
 
         // Obtain the CAN frame time stamp from the kernel.
         // This time stamp is from the CLOCK_REALTIME kernel source.
-        if (NULL != out_timestamp_usec)
-        {
-            const struct cmsghdr* cmsg = CMSG_FIRSTHDR(&msg);
-            struct timeval        tv   = {0};
-            assert(cmsg != NULL);
-            if ((cmsg->cmsg_level == SOL_SOCKET) && (cmsg->cmsg_type == SO_TIMESTAMP))
-            {
-                (void) memcpy(&tv, CMSG_DATA(cmsg), sizeof(tv));  // Copy to avoid alignment problems
-                assert(tv.tv_sec >= 0 && tv.tv_usec >= 0);
-            }
-            else
-            {
-                assert(0);
-                return -EIO;
+        if (out_timestamp_usec != NULL) {
+            struct timespec tss[3] = {{0}};
+            int64_t software_timestamp_ns = 0;
+
+            // Extract the software timestamp from the control messages if present.
+            if (parseTimestampingCmsg(&msg, tss)) {
+                software_timestamp_ns = timespecToNanoseconds(&tss[0]);
             }
 
-            (void) memset(out_frame, 0, sizeof(CanardFrame));
-            *out_timestamp_usec = (CanardMicrosecond) (((uint64_t) tv.tv_sec * MEGA) + (uint64_t) tv.tv_usec);
+            // Fallback: If no software timestamp was found, get the system realtime.
+            if (software_timestamp_ns == 0) {
+                struct timespec ts_fallback = {0};
+                if (clock_gettime(CLOCK_REALTIME, &ts_fallback) == 0) {
+                    software_timestamp_ns = timespecToNanoseconds(&ts_fallback);
+                }
+            }
+            *out_timestamp_usec = (CanardMicrosecond)(software_timestamp_ns / KILO);
         }
+
         out_frame->extended_can_id = sockcan_frame.can_id & CAN_EFF_MASK;
         out_frame->payload_size    = sockcan_frame.len;
         out_frame->payload         = payload_buffer;
@@ -275,6 +401,65 @@ int16_t socketcanPop(const SocketCANFD        fd,
     }
     return poll_result;
 }
+
+int16_t socketcanPopTimestamp(const SocketCANFD        fd,
+                              const CanardMicrosecond  timeout_usec,
+                              uint32_t* const          out_tx_id,
+                              CanardMicrosecond* const out_sw_timestamp_usec,
+                              CanardMicrosecond* const out_raw_hw_timestamp_usec)
+{
+    if (out_sw_timestamp_usec == NULL ||
+        out_raw_hw_timestamp_usec == NULL) {
+        return -EINVAL;
+    }
+
+    const int16_t poll_result = doPoll(fd, POLLIN, timeout_usec);
+    if (poll_result <= 0) {
+        return poll_result;
+    }
+
+    union {
+        uint8_t buf[ CMSG_SPACE(sizeof(struct timespec[3])) +
+                    CMSG_SPACE(sizeof(struct sock_extended_err)) + 64 ];
+        struct cmsghdr align;
+    } control;
+    (void) memset(control.buf, 0, sizeof(control.buf));
+
+    struct msghdr msg = {0};
+    msg.msg_control    = control.buf;
+    msg.msg_controllen = sizeof(control.buf);
+
+    const ssize_t rd = recvmsg(fd, &msg, MSG_ERRQUEUE | MSG_DONTWAIT);
+    if (rd < 0) {
+        if (errno == EAGAIN || errno == EWOULDBLOCK) {
+            return 0;
+        }
+        return getNegatedErrno();
+    }
+
+    if (out_tx_id) {
+        (void)parseTxIDFromErrqueue(&msg, out_tx_id);
+    }
+
+    struct timespec tss[3] = {{0}};
+    (void)parseTimestampingCmsg(&msg, tss);
+    const int64_t sw_ns  = timespecToNanoseconds(&tss[0]); // software (system domain)
+    const int64_t raw_ns = timespecToNanoseconds(&tss[2]); // raw HW (device domain)
+
+    *out_sw_timestamp_usec = (CanardMicrosecond)(sw_ns / NANOSECONDS_PER_MICROSECOND);
+    *out_raw_hw_timestamp_usec = (CanardMicrosecond)(raw_ns / NANOSECONDS_PER_MICROSECOND);
+
+    int64_t chosen_ns = sw_ns;
+
+    if (!chosen_ns) {
+        struct timespec ts_fallback = {0};
+        if (clock_gettime(CLOCK_REALTIME, &ts_fallback) == 0) {
+            chosen_ns = timespecToNanoseconds(&ts_fallback);
+        }
+    }
+    return poll_result;
+}
+
 
 int16_t socketcanFilter(const SocketCANFD fd, const size_t num_configs, const CanardFilter* const configs)
 {

--- a/examples/CAN/host-example-01-opencyphal-basic-node/socketcan.h
+++ b/examples/CAN/host-example-01-opencyphal-basic-node/socketcan.h
@@ -49,15 +49,22 @@ typedef int SocketCANFD;
  *
  * @param[in] iface_name name of the CAN interface, e.g., "can0, vcan0"
  * @param[in] can_fd true for CAN FD mode, false if only classic CAN frames are to be supported.
+ * @param[in] en_rx_timestamping enable reception timestamping if true.
+ * @param[in] en_tx_timestamping enable transmission timestamping if true.
+ * @param[in] enable_frame_reception enable frame reception if true. Otherwise, only transmission is possible.
  *
  * @return socket handle on success, negated errno on error.
  */
-SocketCANFD socketcanOpen(const char* const iface_name, const bool can_fd);
+SocketCANFD socketcanOpen(const char* const iface_name,
+                          const bool can_fd,
+                          const bool en_rx_timestamping,
+                          const bool en_tx_timestamping,
+                          const bool enable_frame_reception);
 
 /**
  * @brief Enqueue a new extended CAN data frame for transmission.
  * Block until the frame is enqueued or until the timeout is expired.
- * 
+ *
  * @param fd the socket handle.
  * @param[in] frame the frame to be transmitted. Zero timeout makes the operation non-blocking.
  * @param timeout_usec timeout in microseconds.
@@ -94,6 +101,25 @@ int16_t socketcanPop(const SocketCANFD        fd,
                      const CanardMicrosecond  timeout_usec,
                      bool* const              loopback);
 
+/**
+ * @brief Fetch one new TX timestamp notification from the errqueue.
+ * Returns the software- and hardware-domain timestamp (fallback to CLOCK_REALTIME).
+ * Call this repeatedly to drain the errqueue.
+ *
+ * @param fd the socket handle.
+ * @param timeout_usec the timeout in microseconds. Zero timeout makes the operation non-blocking.
+ * @param[out] out_tx_id A unique identifier of the transmitted frame associated with this timestamp.
+ *                       The identifier is derived from a per-socket u32 counter (that wraps). Starts with 0.
+ * @param[out] sw_timestamp_usec Software-domain timestamp in microseconds.
+ * @param[out] raw_hw_timestamp_usec Raw hardware-domain timestamp in microseconds. Not aligned to system clock.
+ *
+ * @return 1 if an entry was read, 0 if none (EAGAIN), or negative errno.
+ */
+int16_t socketcanPopTimestamp(const SocketCANFD        fd,
+                              const CanardMicrosecond  timeout_usec,
+                              uint32_t* const          out_tx_id,
+                              CanardMicrosecond* const sw_timestamp_usec,
+                              CanardMicrosecond* const raw_hw_timestamp_usec);
 /**
  * @brief Apply the specified acceptance filter configuration.
  *        Note that it is only possible to accept extended-format data frames.

--- a/src/Node.hpp
+++ b/src/Node.hpp
@@ -83,9 +83,9 @@ public:
 
 
   template <typename T>
-  Publisher<T> create_publisher(CanardMicrosecond const tx_timeout_usec);
+  Publisher<T> create_publisher(CanardMicrosecond const tx_timeout_usec, CanardPriority const priority = CanardPriorityNominal);
   template <typename T>
-  Publisher<T> create_publisher(CanardPortID const port_id, CanardMicrosecond const tx_timeout_usec);
+  Publisher<T> create_publisher(CanardPortID const port_id, CanardMicrosecond const tx_timeout_usec, CanardPriority const priority);
 
   template <typename T, typename OnReceiveCb>
   Subscription create_subscription(OnReceiveCb&& on_receive_cb, CanardMicrosecond const tid_timeout_usec = CANARD_DEFAULT_TRANSFER_ID_TIMEOUT_USEC);

--- a/src/Node.ipp
+++ b/src/Node.ipp
@@ -26,14 +26,14 @@ namespace cyphal
  **************************************************************************************/
 
 template <typename T>
-Publisher<T> Node::create_publisher(CanardMicrosecond const tx_timeout_usec)
+Publisher<T> Node::create_publisher(CanardMicrosecond const tx_timeout_usec, CanardPriority const priority)
 {
   static_assert(T::_traits_::HasFixedPortID, "T does not have a fixed port id.");
-  return create_publisher<T>(T::_traits_::FixedPortId, tx_timeout_usec);
+  return create_publisher<T>(T::_traits_::FixedPortId, tx_timeout_usec, priority);
 }
 
 template <typename T>
-Publisher<T> Node::create_publisher(CanardPortID const port_id, CanardMicrosecond const tx_timeout_usec)
+Publisher<T> Node::create_publisher(CanardPortID const port_id, CanardMicrosecond const tx_timeout_usec, CanardPriority const priority)
 {
   static_assert(!T::_traits_::IsServiceType, "T is not message type");
 
@@ -43,7 +43,8 @@ Publisher<T> Node::create_publisher(CanardPortID const port_id, CanardMicrosecon
   return std::make_shared<impl::Publisher<T>>(
     *this,
     port_id,
-    tx_timeout_usec
+    tx_timeout_usec,
+    priority
     );
 }
 

--- a/src/Publisher.hpp
+++ b/src/Publisher.hpp
@@ -33,11 +33,12 @@ template <typename T>
 class Publisher final : public PublisherBase<T>
 {
 public:
-  Publisher(Node & node_hdl, CanardPortID const port_id, CanardMicrosecond const tx_timeout_usec)
+  Publisher(Node & node_hdl, CanardPortID const port_id, CanardMicrosecond const tx_timeout_usec, CanardPriority const priority)
   : _node_hdl{node_hdl}
   , _port_id{port_id}
   , _tx_timeout_usec{tx_timeout_usec}
   , _transfer_id{0}
+  , _priority{priority}
   { }
   virtual ~Publisher() { }
 
@@ -48,6 +49,7 @@ private:
   CanardPortID const _port_id;
   CanardMicrosecond const _tx_timeout_usec;
   CanardTransferID _transfer_id;
+  CanardPriority _priority;
 };
 
 /**************************************************************************************

--- a/src/Publisher.ipp
+++ b/src/Publisher.ipp
@@ -36,7 +36,7 @@ bool Publisher<T>::publish(T const & msg)
 #pragma GCC diagnostic ignored "-Wpedantic"
   CanardTransferMetadata const transfer_metadata =
   {
-    .priority       = CanardPriorityNominal,
+    .priority       = _priority,
     .transfer_kind  = CanardTransferKindMessage,
     .port_id        = _port_id,
     .remote_node_id = CANARD_NODE_ID_UNSET,


### PR DESCRIPTION
- Add timestamping to socketcan in order to receive them through the socket error queue
- Make publisher priority configurable