### PR TITLE
Replace internal DSDL_Types.h with explicit UAVCAN headers

### DIFF
--- a/src/107-Arduino-Cyphal.h
+++ b/src/107-Arduino-Cyphal.h
@@ -12,7 +12,6 @@
  **************************************************************************************/
 
 #include "Node.hpp"
-#include "DSDL_Types.h"
 #include "Publisher.hpp"
 #include "Subscription.hpp"
 #include "ServiceClient.hpp"

--- a/src/util/nodeinfo/NodeInfoBase.hpp
+++ b/src/util/nodeinfo/NodeInfoBase.hpp
@@ -13,7 +13,7 @@
 
 #include <memory>
 
-#include "../../DSDL_Types.h"
+#include <uavcan/node/GetInfo_1_0.hpp>
 
 /**************************************************************************************
  * NAMESPACE

--- a/src/util/port/PortListPublisher.hpp
+++ b/src/util/port/PortListPublisher.hpp
@@ -14,7 +14,8 @@
 #include "PortListPublisherBase.hpp"
 
 #include "../../Node.hpp"
-#include "../../DSDL_Types.h"
+#include <uavcan/node/port/List_1_0.hpp>
+#include <uavcan/node/port/SubjectID_1_0.hpp>
 
 /**************************************************************************************
  * NAMESPACE

--- a/src/util/registry/Registry.hpp
+++ b/src/util/registry/Registry.hpp
@@ -12,7 +12,8 @@
  **************************************************************************************/
 
 #include "../../Node.hpp"
-#include "../../DSDL_Types.h"
+#include <uavcan/_register/List_1_0.hpp>
+#include <uavcan/_register/Access_1_0.hpp>
 
 #include "registry_impl.hpp"
 

--- a/src/util/registry/registry_value.hpp
+++ b/src/util/registry/registry_value.hpp
@@ -15,7 +15,11 @@
 #include <utility>
 #include <string_view>
 
-#include "../../DSDL_Types.h"
+#include <uavcan/_register/Value_1_0.hpp>
+#include <uavcan/_register/Name_1_0.hpp>
+#include <uavcan/primitive/String_1_0.hpp>
+#include <uavcan/primitive/Unstructured_1_0.hpp>
+#include <uavcan/primitive/Empty_1_0.hpp>
 
 
 


### PR DESCRIPTION
- Remove the `#include "DSDL_Types.h"` monolithic include from the main header and internal utility headers
- Replace with explicit angle-bracket includes for only the specific UAVCAN types each file actually needs (e.g. `<uavcan/node/GetInfo_1_0.hpp>`, `<uavcan/_register/Access_1_0.hpp>`)

###  Motivation
We use this library as a dependency in our internal Software Stack, where DSDL types (including the standard `uavcan` and `reg` namespaces) are already generated by the `filics_dsdl` project. The bundled `DSDL_Types.h` pulls in all types from `src/types/`, which conflicts with the externally generated ones, which are generated from a modified cpp jinja template